### PR TITLE
changed UUID types to INTEGER in models - fixed crash on npm run dev

### DIFF
--- a/server/models/Transaction.js
+++ b/server/models/Transaction.js
@@ -5,8 +5,8 @@ var Sequelize = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
     const Transaction = sequelize.define("Transaction", {
         transactionID: {
-            type: DataTypes.UUID,
-            defaultValue: Sequelize.UUIDV4,
+            type: DataTypes.INTEGER,
+            defaultValue: Sequelize.INTEGER,
             primaryKey: true,
             autoIncrement: true
         },

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -5,8 +5,8 @@ var Sequelize = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
     const User = sequelize.define('User', {
         userID: {
-            type: DataTypes.UUID,
-            defaultValue: Sequelize.UUIDV4,
+            type: DataTypes.INTEGER,
+            defaultValue: Sequelize.INTEGER,
             primaryKey: true,
             autoIncrement: true
         },


### PR DESCRIPTION
fixed crash when running 'npm run dev' or 'npm start'. Datatypes of ID's for models has been changed to INTEGER. 